### PR TITLE
Feat flash message

### DIFF
--- a/app/assets/javascripts/flash_messages.js
+++ b/app/assets/javascripts/flash_messages.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const container = document.getElementById('flash-messages');
+  const flashMessagesDisappearedAfter = container?.dataset.disappearAfter
+    ? parseInt(container.dataset.disappearAfter, 10)
+    : 5000;
+
+  setTimeout(function() {
+    document.querySelectorAll('[id^="flash-message-"]').forEach(function(el) {
+      el.style.opacity = '0';
+      setTimeout(() => el.style.display = 'none', 500);
+    });
+  }, flashMessagesDisappearedAfter);
+});
+
+window.closeFlash = function(idx) {
+  var el = document.getElementById('flash-message-' + idx);
+  if (el) {
+    el.style.opacity = '0';
+    setTimeout(function() { el.style.display = 'none'; }, 500);
+  }
+};

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,23 +22,13 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body class="relative">
+  <body>
     <main class="isolate relative z-10">
-    <% flash.each do |type, message| %>
-          <% alert_class = case type.to_sym
-            when :notice then "bg-blue-100 border-blue-300 text-blue-800"
-            when :alert, :error then "bg-red-100 border-red-300 text-red-800"
-            else "bg-gray-100 border-gray-300 text-gray-800"
-          end %>
-          <div class="max-w-3xl mx-auto mt-4 p-4 rounded border-l-4 shadow-sm <%= alert_class %>">
-            <p class="text-sm font-medium"><%= message %></p>
-          </div>
-        <% end %>
-
+      <%= render "shared/flash" %>
       <%= yield %>
     </main> 
-       
-  <!-- SVG Grid Background -->
+
+  <!-- Grid Background -->
     <svg
       class="fixed inset-0 -z-10 w-full h-full stroke-background-emphasis [mask-image:radial-gradient(32rem_32rem_at_center,white,transparent)]"
       aria-hidden="true">
@@ -61,5 +51,7 @@
           style="clip-path: polygon(63.1% 29.5%, 100% 17.1%, 76.6% 3%, 48.4% 0%, 44.6% 4.7%, 54.5% 25.3%, 59.8% 49%, 55.2% 57.8%, 44.4% 57.2%, 27.8% 47.9%, 35.1% 81.5%, 0% 97.7%, 39.2% 100%, 35.2% 81.4%, 97.2% 52.8%, 63.1% 29.5%)">
         </div>
     </div>
+  <!-- End Grid Background -->
+
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,5 +53,6 @@
     </div>
   <!-- End Grid Background -->
 
+    <%= javascript_include_tag "flash_messages", "data-turbo-track": "reload" %>
   </body>
 </html>

--- a/app/views/pages/learn_more.html.erb
+++ b/app/views/pages/learn_more.html.erb
@@ -2,7 +2,7 @@
     <header class="absolute inset-x-0 top-0 z-10 max-w-7xl mx-auto">
         <nav class="flex items-center justify-between pt-2 px-8" aria-label="Global">
             <%= link_to root_path, class: "p-4" do %>
-                <%= cdn_image :logo_white, class: "h-16", alt: t("landing.company_name") %>
+                <%= cdn_image :logo_white, class: "h-16", alt: t('common.state_force') %>
             <% end %>
 
             <%= link_to "#{t("landing.nav.login")} <span aria-hidden='true'>&rarr;</span>".html_safe, new_user_session_path, class: "text-sm font-semibold p-4" %>
@@ -132,7 +132,7 @@
 
     <footer class="mt-16 sm:mt-32">
         <div class="mx-auto max-w-7xl overflow-hidden px-6 py-20 sm:py-24 lg:px-8">
-            <p class="mt-10 text-center text-sm/6 text-neutral-focus">&copy; StateForce, Inc. All rights reserved.</p>
+            <p class="mt-10 text-center text-sm/6 text-neutral-focus">&copy; <%= t("common.state_force") %>, Inc. All rights reserved.</p>
         </div>
     </footer>
 </div>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -20,14 +20,14 @@
 </div>
 
 <script>
-  const flashMessagesDisaperedAfter = 8000;
+  const flashMessagesDisappearedAfter = 8000;
 
   setTimeout(function() {
     document.querySelectorAll('[id^="flash-message-"]').forEach(function(el) {
       el.style.opacity = '0';
       setTimeout(() => el.style.display = 'none', 500);
     });
-  }, flashMessagesDisaperedAfter);
+  }, flashMessagesDisappearedAfter);
 
   function closeFlash(idx) {
     var el = document.getElementById('flash-message-' + idx);

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,5 +1,7 @@
-<%# Flash messages fixed at the top center, above all content %>
-<div id="flash-messages" class="fixed top-4 left-1/2 -translate-x-1/2 z-50 w-full max-w-3xl px-4 select-none transition-opacity duration-500">
+<div
+  id="flash-messages"
+  class="fixed top-4 left-1/2 -translate-x-1/2 z-50 w-full max-w-3xl px-4 select-none transition-opacity duration-500"
+  data-disappear-after="<%= GLOBAL_VARS[:flash_messages_disappeared_after] || 5000 %>">
   <% flash.each_with_index do |(type, message), idx| %>
     <% alert_class = case type.to_sym
       when :notice then "bg-info border-info-focus text-info-content"
@@ -18,22 +20,3 @@
     </div>
   <% end %>
 </div>
-
-<script>
-  window.flashMessagesDisappearedAfter = <%= GLOBAL_VARS[:flash_messages_disappeared_after] || 5000 %>;
-
-  setTimeout(function() {
-    document.querySelectorAll('[id^="flash-message-"]').forEach(function(el) {
-      el.style.opacity = '0';
-      setTimeout(() => el.style.display = 'none', 500);
-    });
-  }, flashMessagesDisappearedAfter);
-
-  function closeFlash(idx) {
-    var el = document.getElementById('flash-message-' + idx);
-    if (el) {
-      el.style.opacity = '0';
-      setTimeout(function() { el.style.display = 'none'; }, 500);
-    }
-  }
-</script>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,13 +1,39 @@
 <%# Flash messages fixed at the top center, above all content %>
-<div class="fixed top-4 left-1/2 -translate-x-1/2 z-50 w-full max-w-3xl px-4 select-none">
-  <% flash.each do |type, message| %>
+<div id="flash-messages" class="fixed top-4 left-1/2 -translate-x-1/2 z-50 w-full max-w-3xl px-4 select-none transition-opacity duration-500">
+  <% flash.each_with_index do |(type, message), idx| %>
     <% alert_class = case type.to_sym
       when :notice then "bg-info border-info-focus text-info-content"
       when :alert, :error then "bg-danger border-danger-focus text-danger-content"
       else "bg-neutral border-neutral-focus text-neutral-content"
     end %>
-    <div class="mb-2 p-4 rounded border-l-4 shadow-sm <%= alert_class %>">
-      <p class="text-sm font-medium"><%= message %></p>
+    <div id="flash-message-<%= idx %>" class="mb-2 p-4 rounded border-l-4 shadow-sm relative <%= alert_class %> transition-opacity duration-500">
+      <button
+        type="button"
+        aria-label="Close"
+        onclick="closeFlash(<%= idx %>)"
+        class="absolute top-2 right-2 text-xl font-bold leading-none cursor-pointer hover:text-neutral-disabled focus:outline-none">
+            &times;
+        </button>
+      <p class="text-sm font-medium pr-6"><%= message %></p>
     </div>
   <% end %>
 </div>
+
+<script>
+  const flashMessagesDisaperedAfter = 8000;
+
+  setTimeout(function() {
+    document.querySelectorAll('[id^="flash-message-"]').forEach(function(el) {
+      el.style.opacity = '0';
+      setTimeout(() => el.style.display = 'none', 500);
+    });
+  }, flashMessagesDisaperedAfter);
+
+  function closeFlash(idx) {
+    var el = document.getElementById('flash-message-' + idx);
+    if (el) {
+      el.style.opacity = '0';
+      setTimeout(function() { el.style.display = 'none'; }, 500);
+    }
+  }
+</script>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -20,7 +20,7 @@
 </div>
 
 <script>
-  const flashMessagesDisappearedAfter = 8000;
+  window.flashMessagesDisappearedAfter = <%= GLOBAL_VARS[:flash_messages_disappeared_after] || 5000 %>;
 
   setTimeout(function() {
     document.querySelectorAll('[id^="flash-message-"]').forEach(function(el) {

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,0 +1,13 @@
+<%# Flash messages fixed at the top center, above all content %>
+<div class="fixed top-4 left-1/2 -translate-x-1/2 z-50 w-full max-w-3xl px-4 select-none">
+  <% flash.each do |type, message| %>
+    <% alert_class = case type.to_sym
+      when :notice then "bg-info border-info-focus text-info-content"
+      when :alert, :error then "bg-danger border-danger-focus text-danger-content"
+      else "bg-neutral border-neutral-focus text-neutral-content"
+    end %>
+    <div class="mb-2 p-4 rounded border-l-4 shadow-sm <%= alert_class %>">
+      <p class="text-sm font-medium"><%= message %></p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -9,7 +9,7 @@
     <div id="flash-message-<%= idx %>" class="mb-2 p-4 rounded border-l-4 shadow-sm relative <%= alert_class %> transition-opacity duration-500">
       <button
         type="button"
-        aria-label=<%= t('common.close') %>
+        aria-label="<%= t('common.close') %>"
         onclick="closeFlash(<%= idx %>)"
         class="absolute top-2 right-2 text-xl font-bold leading-none cursor-pointer hover:text-neutral-disabled focus:outline-none">
             &times;

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -9,7 +9,7 @@
     <div id="flash-message-<%= idx %>" class="mb-2 p-4 rounded border-l-4 shadow-sm relative <%= alert_class %> transition-opacity duration-500">
       <button
         type="button"
-        aria-label="Close"
+        aria-label=<%= t('common.close') %>
         onclick="closeFlash(<%= idx %>)"
         class="absolute top-2 right-2 text-xl font-bold leading-none cursor-pointer hover:text-neutral-disabled focus:outline-none">
             &times;

--- a/config/initializers/global_vars.rb
+++ b/config/initializers/global_vars.rb
@@ -1,0 +1,3 @@
+GLOBAL_VARS = {
+  flash_messages_disappeared_after: 8000
+}.freeze

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,36 @@
 #       enabled: "ON"
 
 en:
+  common:
+    yes: "Yes"
+    no: "No"
+    ok: "OK"
+    cancel: "Cancel"
+    save: "Save"
+    delete: "Delete"
+    edit: "Edit"
+    back: "Back"
+    next: "Next"
+    previous: "Previous"
+    submit: "Submit"
+    close: "Close"
+    loading: "Loading..."
+    error: "Error"
+    success: "Success"
+    warning: "Warning"
+    info: "Info"
+    confirm: "Confirm"
+    search: "Search"
+    filter: "Filter"
+    clear: "Clear"
+    view: "View"
+    create: "Create"
+    update: "Update"
+    manage: "Manage"
+    help: "Help"
+    learn_more: "Learn more"
+    terms_of_service: "Terms of Service"
+    privacy_policy: "Privacy Policy"
   landing:
     company_name: StateForce
     nav:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,6 +58,7 @@ en:
     learn_more: "Learn more"
     terms_of_service: "Terms of Service"
     privacy_policy: "Privacy Policy"
+    state_force: "StateForce"
   landing:
     company_name: StateForce
     nav:

--- a/test/system/flash_messages_test.rb
+++ b/test/system/flash_messages_test.rb
@@ -22,7 +22,7 @@ class FlashMessagesTest < ActionDispatch::SystemTestCase
     click_on I18n.t("devise.sessions.sign_in")
 
     assert_selector "#flash-messages .mb-2", visible: true
-    assert_no_selector "#flash-messages .mb-2", visible: true, wait: 8.5
+    assert_no_selector "#flash-messages .mb-2", visible: true, wait: GLOBAL_VARS[:flash_messages_disappeared_after] + 0.5
   end
 
   test "flash message can be closed manually" do
@@ -32,13 +32,13 @@ class FlashMessagesTest < ActionDispatch::SystemTestCase
 
     assert_selector "#flash-messages .mb-2", visible: true
     find("#flash-messages button[aria-label]").click
-    assert_no_selector "#flash-messages .mb-2", visible: true, wait: 0.6
+    assert_no_selector "#flash-messages .mb-2", visible: true, wait: 0.5
   end
 
   test "flash message for notice has correct color classes" do
     user_auth =  {
       email: Faker::Internet.email,
-      uid: "1234567890",
+      uid: Faker::Number.number(digits: 10),
       name: Faker::Name.name
     }
 

--- a/test/system/flash_messages_test.rb
+++ b/test/system/flash_messages_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "faker"
+
+class FlashMessagesTest < ActionDispatch::SystemTestCase
+  def setup
+    @user = users(:user_one)
+
+    visit new_user_session_path
+  end
+
+  def teardown
+    page.execute_script(%Q{
+      fetch("#{destroy_user_session_path}", {method: "DELETE", credentials: "same-origin"});
+    })
+  end
+
+  test "flash message appears and disappears after 8 seconds" do
+    fill_in I18n.t("devise.registrations.email"), with: @user.email
+    fill_in I18n.t("devise.registrations.password"), with: "wrong_password"
+    click_on I18n.t("devise.sessions.sign_in")
+
+    assert_selector "#flash-messages .mb-2", visible: true
+    sleep 8.5
+    assert_no_selector "#flash-messages .mb-2", visible: true
+  end
+
+  test "flash message can be closed manually" do
+    fill_in I18n.t("devise.registrations.email"), with: @user.email
+    fill_in I18n.t("devise.registrations.password"), with: "wrong_password"
+    click_on I18n.t("devise.sessions.sign_in")
+
+    assert_selector "#flash-messages .mb-2", visible: true
+    find("#flash-messages button[aria-label]").click
+    sleep 0.6
+    assert_no_selector "#flash-messages .mb-2", visible: true
+  end
+
+  test "flash message for notice has correct color classes" do
+    user_auth =  {
+      email: Faker::Internet.email,
+      uid: "1234567890",
+      name: Faker::Name.name
+    }
+
+    mock_google_auth(email: user_auth[:email], uid: user_auth[:uid], name: user_auth[:name])
+    visit new_user_session_path
+    click_on I18n.t("devise.providers.google")
+
+    assert_selector "#flash-messages .bg-info.border-info-focus.text-info-content", visible: true
+  end
+
+  test "flash message for alert has correct color classes" do
+    visit new_user_session_path
+    fill_in I18n.t("devise.registrations.email"), with: @user.email
+    fill_in I18n.t("devise.registrations.password"), with: "wrong_password"
+    click_on I18n.t("devise.sessions.sign_in")
+    assert_selector "#flash-messages .bg-danger.border-danger-focus.text-danger-content", visible: true
+  end
+
+  test "flash message for error has correct color classes" do
+    visit new_user_session_path
+    fill_in I18n.t("devise.registrations.email"), with: @user.email
+    fill_in I18n.t("devise.registrations.password"), with: "wrong_password"
+    click_on I18n.t("devise.sessions.sign_in")
+    assert_selector "#flash-messages .bg-danger.border-danger-focus.text-danger-content", visible: true
+  end
+end

--- a/test/system/flash_messages_test.rb
+++ b/test/system/flash_messages_test.rb
@@ -22,8 +22,7 @@ class FlashMessagesTest < ActionDispatch::SystemTestCase
     click_on I18n.t("devise.sessions.sign_in")
 
     assert_selector "#flash-messages .mb-2", visible: true
-    sleep 8.5
-    assert_no_selector "#flash-messages .mb-2", visible: true
+    assert_no_selector "#flash-messages .mb-2", visible: true, wait: 8.5
   end
 
   test "flash message can be closed manually" do
@@ -33,8 +32,7 @@ class FlashMessagesTest < ActionDispatch::SystemTestCase
 
     assert_selector "#flash-messages .mb-2", visible: true
     find("#flash-messages button[aria-label]").click
-    sleep 0.6
-    assert_no_selector "#flash-messages .mb-2", visible: true
+    assert_no_selector "#flash-messages .mb-2", visible: true, wait: 0.6
   end
 
   test "flash message for notice has correct color classes" do

--- a/test/system/flash_messages_test.rb
+++ b/test/system/flash_messages_test.rb
@@ -37,9 +37,7 @@ class FlashMessagesTest < ActionDispatch::SystemTestCase
       uid: Faker::Number.number(digits: 10),
       name: Faker::Name.name
     }
-
     mock_google_auth(email: user_auth[:email], uid: user_auth[:uid], name: user_auth[:name])
-    visit new_user_session_path
     click_on I18n.t("devise.providers.google")
 
     assert_selector "#flash-messages .bg-info.border-info-focus.text-info-content", visible: true
@@ -59,8 +57,6 @@ class FlashMessagesTest < ActionDispatch::SystemTestCase
 
   private
   def wrong_login
-    visit new_user_session_path
-
     fill_in I18n.t("devise.registrations.email"), with: @user.email
     fill_in I18n.t("devise.registrations.password"), with: "wrong_password"
     click_on I18n.t("devise.sessions.sign_in")

--- a/test/system/flash_messages_test.rb
+++ b/test/system/flash_messages_test.rb
@@ -17,18 +17,14 @@ class FlashMessagesTest < ActionDispatch::SystemTestCase
   end
 
   test "flash message appears and disappears after 8 seconds" do
-    fill_in I18n.t("devise.registrations.email"), with: @user.email
-    fill_in I18n.t("devise.registrations.password"), with: "wrong_password"
-    click_on I18n.t("devise.sessions.sign_in")
+    wrong_login
 
     assert_selector "#flash-messages .mb-2", visible: true
     assert_no_selector "#flash-messages .mb-2", visible: true, wait: GLOBAL_VARS[:flash_messages_disappeared_after] + 0.5
   end
 
   test "flash message can be closed manually" do
-    fill_in I18n.t("devise.registrations.email"), with: @user.email
-    fill_in I18n.t("devise.registrations.password"), with: "wrong_password"
-    click_on I18n.t("devise.sessions.sign_in")
+    wrong_login
 
     assert_selector "#flash-messages .mb-2", visible: true
     find("#flash-messages button[aria-label]").click
@@ -50,18 +46,23 @@ class FlashMessagesTest < ActionDispatch::SystemTestCase
   end
 
   test "flash message for alert has correct color classes" do
-    visit new_user_session_path
-    fill_in I18n.t("devise.registrations.email"), with: @user.email
-    fill_in I18n.t("devise.registrations.password"), with: "wrong_password"
-    click_on I18n.t("devise.sessions.sign_in")
+    wrong_login
+
     assert_selector "#flash-messages .bg-danger.border-danger-focus.text-danger-content", visible: true
   end
 
   test "flash message for error has correct color classes" do
+    wrong_login
+
+    assert_selector "#flash-messages .bg-danger.border-danger-focus.text-danger-content", visible: true
+  end
+
+  private
+  def wrong_login
     visit new_user_session_path
+
     fill_in I18n.t("devise.registrations.email"), with: @user.email
     fill_in I18n.t("devise.registrations.password"), with: "wrong_password"
     click_on I18n.t("devise.sessions.sign_in")
-    assert_selector "#flash-messages .bg-danger.border-danger-focus.text-danger-content", visible: true
   end
 end

--- a/test/system/flash_messages_test.rb
+++ b/test/system/flash_messages_test.rb
@@ -16,7 +16,7 @@ class FlashMessagesTest < ActionDispatch::SystemTestCase
     })
   end
 
-  test "flash message appears and disappears after 8 seconds" do
+  test "flash message appears and disappears after X seconds" do
     wrong_login
 
     assert_selector "#flash-messages .mb-2", visible: true

--- a/test/system/sign_in_test.rb
+++ b/test/system/sign_in_test.rb
@@ -59,9 +59,9 @@ class SignInTest < ActionDispatch::SystemTestCase
 
   test "user can sign in with Google" do
     user_auth =  {
-      email: "user2@stateforce.mx",
+      email: Faker::Internet.email,
       uid: "1234567890",
-      name: "User 2 Last"
+      name: Faker::Name.name
     }
 
     mock_google_auth(email: user_auth[:email], uid: user_auth[:uid], name: user_auth[:name])

--- a/test/system/sign_in_test.rb
+++ b/test/system/sign_in_test.rb
@@ -68,6 +68,6 @@ class SignInTest < ActionDispatch::SystemTestCase
     visit new_user_session_path
     click_on I18n.t("devise.providers.google")
     assert_current_path dashboard_path
-    assert_text "user2@stateforce.mx"
+    assert_text user_auth[:email]
   end
 end


### PR DESCRIPTION
## 📋 Pull Request Template

### Description

This PR introduces a reusable flash message component to display system messages such as `notice`, `alert`, and `error` in a consistent and visually styled manner across the application.
The component is styled using TailwindCSS and supports conditional rendering and optional dismiss functionality.

---

### Related Issues

Closes #10
References #28 

---

### Changes Made

* [x] Feature added
* [ ] Bug fix
* [ ] Documentation update
* [ ] Code refactor
* [ ] Other (please explain)

> List the main technical changes made in this PR:

* Created a reusable partial/component to render flash messages from Rails controllers
* Applied TailwindCSS styling:

  * Green for `notice`
  * Red for `alert`
  * Optional styles for `error` or other custom keys
* Added dismiss functionality to allow users to close flash messages manually

---

### Screenshots (if applicable)

> *Add screenshots or GIFs demonstrating the flash messages with different types and dismiss interaction*

---

### Checklist

* [x] The code follows the style guidelines of this project
* [x] New and existing tests pass locally
* [x] I have performed a self-review of my code
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have updated documentation as needed

---

### Notes for Reviewers

Let me know if additional message types (e.g., `info`, `warning`) should be supported or if we want to persist messages across redirects with a delay.
The component was built with flexibility in mind for future enhancements like icons or animations.
